### PR TITLE
Add parameter "cluster" and fix "gcloud container clusters get-credentials" command

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -20,6 +20,9 @@ commands:
   rollout-image:
     description: "Update a deployment's Docker image."
     parameters:
+      cluster:
+        description: "The Kubernetes cluster name."
+        type: string
       deployment:
         description: "The Kubernetes deployment name."
         type: string
@@ -31,7 +34,7 @@ commands:
         type: string
     steps:
       - run: |
-          gcloud container clusters get-credentials <<parameters.deployment>>
+          gcloud container clusters get-credentials <<parameters.cluster>>
           kubectl set image deployment <<parameters.deployment>> <<parameters.container>>=<<parameters.image>>
 
 jobs:


### PR DESCRIPTION
I get this issue #2, the problem is because you use `deployment` name instead of `cluster` name when running `gcloud container clusters get-credentials` command.
In this PR I add parameter `cluster` and change parameter in `gcloud container clusters get-credentials` to that parameter.

Fixes #2.