### PR TITLE
Add optional namespace parameter

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -32,10 +32,14 @@ commands:
       image:
         description: A name for your docker image
         type: string
+      namespace:
+        description: "The Kubernetes namespace name."
+        type: string
+        default: "default"
     steps:
       - run: |
           gcloud container clusters get-credentials <<parameters.cluster>>
-          kubectl set image deployment <<parameters.deployment>> <<parameters.container>>=<<parameters.image>>
+          kubectl -n <<parameters.namespace>> set image deployment <<parameters.deployment>> <<parameters.container>>=<<parameters.image>>
 
 jobs:
   publish-and-rollout-image:
@@ -48,6 +52,10 @@ jobs:
       deployment:
         description: "The Kubernetes deployment name."
         type: string
+      namespace:
+        description: "The Kubernetes namespace name."
+        type: string
+        default: "default"
       container:
         description: "The Kubernetes container name."
         type: string
@@ -98,6 +106,7 @@ jobs:
       - rollout-image:
           cluster: "<<parameters.cluster>>"
           deployment: "<<parameters.deployment>>"
+          namespace: "<<parameters.namespace>>"
           container: "<<parameters.container>>"
           image: "<<parameters.image>>"
 


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary


### Motivation, issues

With the current version it is not possible to deploy k8s resources within a namespace other than "default". 


### Description

This change adds another parameter `namespace` with a default value of `default`
and passes it down to the `kubectl set image deploy` command.

The change is backwards compatible as the new parameter is optional and the default value 
is the same as the default of `kubectl`