### PR TITLE
Upgrade gcp-gcr version to 0.6.1

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -4,7 +4,7 @@ description: Google Kubernetes Engine (GKE) Orb
 # Orb Dependencies
 orbs:
   gcloud: circleci/gcp-cli@1.0.6
-  gcr: circleci/gcp-gcr@0.0.2
+  gcr: circleci/gcp-gcr@0.6.1
   k8s: circleci/kubernetes@0.1.0
 
 commands:
@@ -89,7 +89,7 @@ jobs:
           google-project-id: <<parameters.google-project-id>>
           image: <<parameters.image>>
           tag: << parameters.tag >>
-          path-to-dockerfile: <<parameters.path-to-dockerfile>>
+          path: <<parameters.path-to-dockerfile>>
       - gcr/push-image:
           registry-url: <<parameters.registry-url>>
           google-project-id: <<parameters.google-project-id>>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

The gcp-gcr version used is very old


### Description

* Bumps gcp-gcr version from 0.0.2 -> 0.6.1
* changes `path-to-dockerfile` in the call to `gcr/build-image` to `path`
