### PR TITLE
handle docker tag in `rollout-image`

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -32,10 +32,13 @@ commands:
       image:
         description: A name for your docker image
         type: string
+      tag:
+        type: string
+        description: A Docker image tag
     steps:
       - run: |
           gcloud container clusters get-credentials <<parameters.cluster>>
-          kubectl set image deployment <<parameters.deployment>> <<parameters.container>>=<<parameters.image>>
+          kubectl set image deployment <<parameters.deployment>> <<parameters.container>>=<<parameters.image>>:<<parameters.tag>>
 
 jobs:
   publish-and-rollout-image:
@@ -100,6 +103,7 @@ jobs:
           deployment: "<<parameters.deployment>>"
           container: "<<parameters.container>>"
           image: "<<parameters.image>>"
+          tag: "<< parameters.tag >>"
 
 example:
   publish-and-rollout-image:


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
Closes #5

this is important because the tag will be set for GCR but
will not be set when trying to rollout - which will cause
a failure

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
Add support for `tag` to the command `rollout-image`