### PR TITLE
Add --quiet flag to delete-node-pool command [semver:patch]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,7 @@ orb_promotion_filters: &orb_promotion_filters
     only: /^(major|minor|patch)-release-v\d+\.\d+\.\d+$/
 
 orbs:
-  # TODO: set to new major release version of orb-tools once available
-  orb-tools: circleci/orb-tools@dev:newworkflow
+  orb-tools: circleci/orb-tools@9.0.0
   gcp-gke: circleci/gcp-gke@<<pipeline.parameters.dev-orb-version>>
   gcp-gcr: circleci/gcp-gcr@0.6.1
   kubernetes: circleci/kubernetes@0.10.0

--- a/src/commands/create-node-pool.yml
+++ b/src/commands/create-node-pool.yml
@@ -36,7 +36,7 @@ parameters:
       Elapsed time that the node pool creation command can run on CircleCI without output.
       The string is a decimal with unit suffix, such as “20m”, “1.25h”, “5s”
     type: string
-    default: "15m"
+    default: "20m"
 
 steps:
   - gcloud/install

--- a/src/commands/delete-node-pool.yml
+++ b/src/commands/delete-node-pool.yml
@@ -36,7 +36,7 @@ parameters:
       Elapsed time that the node pool deletion command can run on CircleCI without output.
       The string is a decimal with unit suffix, such as “20m”, “1.25h”, “5s”
     type: string
-    default: "12m"
+    default: "15m"
 
 steps:
   - gcloud/install
@@ -50,5 +50,7 @@ steps:
   - run:
       name: Delete node pool
       command: |
-        gcloud container node-pools delete <<parameters.node-pool>> --cluster <<parameters.cluster >> <<parameters.additional-args>>
+        gcloud container node-pools delete <<parameters.node-pool>> \
+          --cluster <<parameters.cluster >> \
+          --quiet <<parameters.additional-args>>
       no_output_timeout: <<parameters.no-output-timeout>>

--- a/src/jobs/create-node-pool.yml
+++ b/src/jobs/create-node-pool.yml
@@ -38,7 +38,7 @@ parameters:
       Elapsed time that the node pool creation command can run on CircleCI without output.
       The string is a decimal with unit suffix, such as “20m”, “1.25h”, “5s”
     type: string
-    default: "15m"
+    default: "20m"
   executor:
     description: >
         Executor to use for this job

--- a/src/jobs/delete-node-pool.yml
+++ b/src/jobs/delete-node-pool.yml
@@ -38,7 +38,7 @@ parameters:
       Elapsed time that the node pool deletion command can run on CircleCI without output.
       The string is a decimal with unit suffix, such as “20m”, “1.25h”, “5s”
     type: string
-    default: "12m"
+    default: "15m"
   executor:
     description: >
         Executor to use for this job


### PR DESCRIPTION
- Add the --quiet flag to the `delete-node-pool` command so that a `Do you want to continue (Y/n)? ` prompt message won't be shown (although the command succeeds even with the prompt shown, it may be confusing for users who notice the prompt; see https://circleci.com/gh/CircleCI-Public/gcp-gke-orb/122 for an example of the prompt)
- Increase the default value of the `no-output-timeout` parameter
- Use production release version of orb-tools-orb in builds