### PR TITLE
Add docker context param to build-image command [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ orbs:
   orb-tools: circleci/orb-tools@9.0.0
   gcp-gke: circleci/gcp-gke@<<pipeline.parameters.dev-orb-version>>
   gcp-gcr: circleci/gcp-gcr@0.8.0
-  kubernetes: circleci/kubernetes@0.10.0
+  kubernetes: circleci/kubernetes@dev:alpha
 
 parameters:
   run-integration-tests:
@@ -54,6 +54,7 @@ jobs:
           tag: $CIRCLE_SHA1
           dockerfile: Dockerfile
           path: /home/circleci/project/tests/demoapp
+          docker-context: /home/circleci/project/tests/demoapp
       - gcp-gcr/push-image:
           image: << parameters.docker-image-name >>
           tag: $CIRCLE_SHA1
@@ -61,6 +62,7 @@ jobs:
           resource-file-path: "tests/demoapp/deployment.yaml"
           get-rollout-status: true
           resource-name: deployment/demoapp
+
   create-deployment-windows:
     parameters:
       cluster-name:
@@ -81,6 +83,7 @@ jobs:
           resource-file-path: "tests/windows-iis/deployment.yaml"
           resource-name: "deployment/iis"
           get-rollout-status: true
+          watch-timeout: 20m
       - run:
           name: Expose deployment via a service
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,64 +132,64 @@ workflows:
   integration-tests_prod-release:
     when: << pipeline.parameters.run-integration-tests >>
     jobs:
-      # - gcp-gke/create-cluster:
-      #     name: create-cluster-linux
-      #     cluster: my-cluster
-      # - gcp-gke/create-cluster:
-      #     name: create-cluster-windows
-      #     cluster: my-cluster-windows
-      #     additional-args: "--cluster-version=1.14 --enable-ip-alias --num-nodes=1"
-      # - gcp-gke/create-node-pool:
-      #     name: create-node-pool-windows
-      #     node-pool: my-pool-windows
-      #     cluster: my-cluster-windows
-      #     additional-args: "--image-type=WINDOWS_SAC --no-enable-autoupgrade --machine-type=n1-standard-2 --num-nodes=1"
-      #     requires:
-      #       - create-cluster-windows
-      # - create-deployment-linux:
-      #     requires:
-      #       - create-cluster-linux
-      #     cluster-name: my-cluster
-      #     full-image-name: gcr.io/$GOOGLE_PROJECT_ID/my-image
-      #     docker-image-name: my-image
-      #     version-info: $CIRCLE_SHA1
-      # - create-deployment-windows:
-      #     requires:
-      #       - create-node-pool-windows
-      #     cluster-name: my-cluster-windows
-      # - gcp-gke/publish-and-rollout-image:
-      #     post-steps:
-      #       - kubernetes/get-rollout-status:
-      #           resource-name: deployment/demoapp
-      #           watch-rollout-status: true
-      #           watch-timeout: 3m
-      #           namespace: default
-      #     requires:
-      #       - create-deployment-linux
-      #     cluster: my-cluster
-      #     deployment: demoapp
-      #     container: app
-      #     image: my-image
-      #     tag: $CIRCLE_SHA1
-      #     namespace: default
-      #     dockerfile-name: tests/demoapp/Dockerfile
-      #     dockerfile-dir: /home/circleci/project/tests/demoapp
+      - gcp-gke/create-cluster:
+          name: create-cluster-linux
+          cluster: my-cluster
+      - gcp-gke/create-cluster:
+          name: create-cluster-windows
+          cluster: my-cluster-windows
+          additional-args: "--cluster-version=1.14 --enable-ip-alias --num-nodes=1"
+      - gcp-gke/create-node-pool:
+          name: create-node-pool-windows
+          node-pool: my-pool-windows
+          cluster: my-cluster-windows
+          additional-args: "--image-type=WINDOWS_SAC --no-enable-autoupgrade --machine-type=n1-standard-2 --num-nodes=1"
+          requires:
+            - create-cluster-windows
+      - create-deployment-linux:
+          requires:
+            - create-cluster-linux
+          cluster-name: my-cluster
+          full-image-name: gcr.io/$GOOGLE_PROJECT_ID/my-image
+          docker-image-name: my-image
+          version-info: $CIRCLE_SHA1
+      - create-deployment-windows:
+          requires:
+            - create-node-pool-windows
+          cluster-name: my-cluster-windows
+      - gcp-gke/publish-and-rollout-image:
+          post-steps:
+            - kubernetes/get-rollout-status:
+                resource-name: deployment/demoapp
+                watch-rollout-status: true
+                watch-timeout: 3m
+                namespace: default
+          requires:
+            - create-deployment-linux
+          cluster: my-cluster
+          deployment: demoapp
+          container: app
+          image: my-image
+          tag: $CIRCLE_SHA1
+          namespace: default
+          dockerfile-name: tests/demoapp/Dockerfile
+          dockerfile-dir: /home/circleci/project/tests/demoapp
       - gcp-gke/delete-node-pool:
           name: delete-node-pool-windows
           node-pool: my-pool-windows
           cluster: my-cluster-windows
-          # requires:
-          #   - create-deployment-windows
+          requires:
+            - create-deployment-windows
       - gcp-gke/delete-cluster:
           name: delete-cluster-linux
           cluster: my-cluster
-          # requires:
-          #   - gcp-gke/publish-and-rollout-image
+          requires:
+            - gcp-gke/publish-and-rollout-image
       - gcp-gke/delete-cluster:
           name: delete-cluster-windows
           cluster: my-cluster-windows
-          # requires:
-          #   - delete-node-pool-windows
+          requires:
+            - delete-node-pool-windows
       - orb-tools/dev-promote-prod-from-commit-subject:
           orb-name: circleci/gcp-gke
           context: orb-publishing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ orbs:
   orb-tools: circleci/orb-tools@9.0.0
   gcp-gke: circleci/gcp-gke@<<pipeline.parameters.dev-orb-version>>
   gcp-gcr: circleci/gcp-gcr@0.8.0
-  kubernetes: circleci/kubernetes@dev:alpha
+  kubernetes: circleci/kubernetes@0.11.0
 
 parameters:
   run-integration-tests:
@@ -83,8 +83,6 @@ jobs:
           resource-file-path: "tests/windows-iis/deployment.yaml"
           resource-name: "deployment/iis"
           get-rollout-status: true
-          watch-timeout: 20m
-          step-timeout: 20m
       - run:
           name: Expose deployment via a service
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,8 +175,9 @@ workflows:
           image: my-image
           tag: $CIRCLE_SHA1
           namespace: default
-          dockerfile-name: tests/demoapp/Dockerfile
+          dockerfile-name: Dockerfile
           dockerfile-dir: /home/circleci/project/tests/demoapp
+          docker-context: /home/circleci/project/tests/demoapp
       - gcp-gke/delete-node-pool:
           name: delete-node-pool-windows
           node-pool: my-pool-windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,64 +132,64 @@ workflows:
   integration-tests_prod-release:
     when: << pipeline.parameters.run-integration-tests >>
     jobs:
-      - gcp-gke/create-cluster:
-          name: create-cluster-linux
-          cluster: my-cluster
-      - gcp-gke/create-cluster:
-          name: create-cluster-windows
-          cluster: my-cluster-windows
-          additional-args: "--cluster-version=1.14 --enable-ip-alias --num-nodes=1"
-      - gcp-gke/create-node-pool:
-          name: create-node-pool-windows
-          node-pool: my-pool-windows
-          cluster: my-cluster-windows
-          additional-args: "--image-type=WINDOWS_SAC --no-enable-autoupgrade --machine-type=n1-standard-2 --num-nodes=1"
-          requires:
-            - create-cluster-windows
-      - create-deployment-linux:
-          requires:
-            - create-cluster-linux
-          cluster-name: my-cluster
-          full-image-name: gcr.io/$GOOGLE_PROJECT_ID/my-image
-          docker-image-name: my-image
-          version-info: $CIRCLE_SHA1
-      - create-deployment-windows:
-          requires:
-            - create-node-pool-windows
-          cluster-name: my-cluster-windows
-      - gcp-gke/publish-and-rollout-image:
-          post-steps:
-            - kubernetes/get-rollout-status:
-                resource-name: deployment/demoapp
-                watch-rollout-status: true
-                watch-timeout: 3m
-                namespace: default
-          requires:
-            - create-deployment-linux
-          cluster: my-cluster
-          deployment: demoapp
-          container: app
-          image: my-image
-          tag: $CIRCLE_SHA1
-          namespace: default
-          dockerfile-name: tests/demoapp/Dockerfile
-          dockerfile-dir: /home/circleci/project/tests/demoapp
+      # - gcp-gke/create-cluster:
+      #     name: create-cluster-linux
+      #     cluster: my-cluster
+      # - gcp-gke/create-cluster:
+      #     name: create-cluster-windows
+      #     cluster: my-cluster-windows
+      #     additional-args: "--cluster-version=1.14 --enable-ip-alias --num-nodes=1"
+      # - gcp-gke/create-node-pool:
+      #     name: create-node-pool-windows
+      #     node-pool: my-pool-windows
+      #     cluster: my-cluster-windows
+      #     additional-args: "--image-type=WINDOWS_SAC --no-enable-autoupgrade --machine-type=n1-standard-2 --num-nodes=1"
+      #     requires:
+      #       - create-cluster-windows
+      # - create-deployment-linux:
+      #     requires:
+      #       - create-cluster-linux
+      #     cluster-name: my-cluster
+      #     full-image-name: gcr.io/$GOOGLE_PROJECT_ID/my-image
+      #     docker-image-name: my-image
+      #     version-info: $CIRCLE_SHA1
+      # - create-deployment-windows:
+      #     requires:
+      #       - create-node-pool-windows
+      #     cluster-name: my-cluster-windows
+      # - gcp-gke/publish-and-rollout-image:
+      #     post-steps:
+      #       - kubernetes/get-rollout-status:
+      #           resource-name: deployment/demoapp
+      #           watch-rollout-status: true
+      #           watch-timeout: 3m
+      #           namespace: default
+      #     requires:
+      #       - create-deployment-linux
+      #     cluster: my-cluster
+      #     deployment: demoapp
+      #     container: app
+      #     image: my-image
+      #     tag: $CIRCLE_SHA1
+      #     namespace: default
+      #     dockerfile-name: tests/demoapp/Dockerfile
+      #     dockerfile-dir: /home/circleci/project/tests/demoapp
       - gcp-gke/delete-node-pool:
           name: delete-node-pool-windows
           node-pool: my-pool-windows
           cluster: my-cluster-windows
-          requires:
-            - create-deployment-windows
+          # requires:
+          #   - create-deployment-windows
       - gcp-gke/delete-cluster:
           name: delete-cluster-linux
           cluster: my-cluster
-          requires:
-            - gcp-gke/publish-and-rollout-image
+          # requires:
+          #   - gcp-gke/publish-and-rollout-image
       - gcp-gke/delete-cluster:
           name: delete-cluster-windows
           cluster: my-cluster-windows
-          requires:
-            - delete-node-pool-windows
+          # requires:
+          #   - delete-node-pool-windows
       - orb-tools/dev-promote-prod-from-commit-subject:
           orb-name: circleci/gcp-gke
           context: orb-publishing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,6 @@ jobs:
           resource-file-path: "tests/demoapp/deployment.yaml"
           get-rollout-status: true
           resource-name: deployment/demoapp
-          step-timeout: 20m
 
   create-deployment-windows:
     parameters:
@@ -84,6 +83,7 @@ jobs:
           resource-file-path: "tests/windows-iis/deployment.yaml"
           resource-name: "deployment/iis"
           get-rollout-status: true
+          watch-timeout: 20m
           step-timeout: 20m
       - run:
           name: Expose deployment via a service

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,8 @@ jobs:
       - gcp-gcr/build-image:
           image: << parameters.docker-image-name >>
           tag: $CIRCLE_SHA1
-          dockerfile: tests/demoapp/Dockerfile
+          dockerfile: Dockerfile
           path: /home/circleci/project/tests/demoapp
-          docker-context: /home/circleci/project/tests/demoapp
       - gcp-gcr/push-image:
           image: << parameters.docker-image-name >>
           tag: $CIRCLE_SHA1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ orbs:
   orb-tools: circleci/orb-tools@9.0.0
   gcp-gke: circleci/gcp-gke@<<pipeline.parameters.dev-orb-version>>
   gcp-gcr: circleci/gcp-gcr@0.8.0
-  kubernetes: circleci/kubernetes@0.11.0
+  kubernetes: circleci/kubernetes@dev:alpha
 
 parameters:
   run-integration-tests:
@@ -83,6 +83,8 @@ jobs:
           resource-file-path: "tests/windows-iis/deployment.yaml"
           resource-name: "deployment/iis"
           get-rollout-status: true
+          watch-timeout: 20m
+          step-timeout: 20m
       - run:
           name: Expose deployment via a service
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
           resource-file-path: "tests/demoapp/deployment.yaml"
           get-rollout-status: true
           resource-name: deployment/demoapp
+          step-timeout: 20m
 
   create-deployment-windows:
     parameters:
@@ -83,7 +84,7 @@ jobs:
           resource-file-path: "tests/windows-iis/deployment.yaml"
           resource-name: "deployment/iis"
           get-rollout-status: true
-          watch-timeout: 20m
+          step-timeout: 20m
       - run:
           name: Expose deployment via a service
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ orb_promotion_filters: &orb_promotion_filters
 orbs:
   orb-tools: circleci/orb-tools@9.0.0
   gcp-gke: circleci/gcp-gke@<<pipeline.parameters.dev-orb-version>>
-  gcp-gcr: circleci/gcp-gcr@0.6.1
+  gcp-gcr: circleci/gcp-gcr@0.8.0
   kubernetes: circleci/kubernetes@0.10.0
 
 parameters:
@@ -54,6 +54,7 @@ jobs:
           tag: $CIRCLE_SHA1
           dockerfile: tests/demoapp/Dockerfile
           path: /home/circleci/project/tests/demoapp
+          docker-context: /home/circleci/project/tests/demoapp
       - gcp-gcr/push-image:
           image: << parameters.docker-image-name >>
           tag: $CIRCLE_SHA1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ orbs:
   orb-tools: circleci/orb-tools@9.0.0
   gcp-gke: circleci/gcp-gke@<<pipeline.parameters.dev-orb-version>>
   gcp-gcr: circleci/gcp-gcr@0.8.0
-  kubernetes: circleci/kubernetes@dev:alpha
+  kubernetes: circleci/kubernetes@0.11.0
 
 parameters:
   run-integration-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,8 +83,6 @@ jobs:
           resource-file-path: "tests/windows-iis/deployment.yaml"
           resource-name: "deployment/iis"
           get-rollout-status: true
-          watch-timeout: 20m
-          step-timeout: 20m
       - run:
           name: Expose deployment via a service
           command: |

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -8,4 +8,4 @@ display:
 orbs:
   gcloud: circleci/gcp-cli@1.8.3
   gcr: circleci/gcp-gcr@0.8.0
-  k8s: circleci/kubernetes@0.10.0
+  k8s: circleci/kubernetes@0.11.0

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -7,5 +7,5 @@ display:
 
 orbs:
   gcloud: circleci/gcp-cli@1.8.3
-  gcr: circleci/gcp-gcr@0.6.1
+  gcr: circleci/gcp-gcr@0.8.0
   k8s: circleci/kubernetes@0.10.0

--- a/src/jobs/publish-and-rollout-image.yml
+++ b/src/jobs/publish-and-rollout-image.yml
@@ -40,7 +40,7 @@ parameters:
     default: ""
   dockerfile-dir:
     description: >
-        Path to the directory containing your Dockerfile and build context,
+        Path to the directory containing your Dockerfile,
         defaults to . (working directory)
     type: string
     default: .
@@ -72,6 +72,12 @@ parameters:
       If server strategy, submit server-side request without persisting the resource.
     type: enum
     enum: ["none", "server", "client"]
+  docker-context:
+    type: string
+    default: .
+    description: >
+      Path to the directory containing your build context, defaults to .
+      (working directory)
 steps:
   - when:
       condition: <<parameters.use-remote-docker>>
@@ -90,6 +96,7 @@ steps:
       tag: << parameters.tag >>
       path: <<parameters.dockerfile-dir>>
       dockerfile: <<parameters.dockerfile-name>>
+      docker-context: <<parameters.docker-context>>
       extra_build_args: <<parameters.extra-build-args>>
   - gcr/push-image:
       registry-url: <<parameters.registry-url>>

--- a/tests/windows-iis/deployment.yaml
+++ b/tests/windows-iis/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: iis
 spec:
-  progressDeadlineSeconds: 1200
   replicas: 1
   selector:
     matchLabels:

--- a/tests/windows-iis/deployment.yaml
+++ b/tests/windows-iis/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: iis
 spec:
+  progressDeadlineSeconds: 1200
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
Fix for #30 after https://github.com/CircleCI-Public/gcp-gcr-orb/pull/38 is merged

### Description

Update the gcr orb and provide the docker context
separate from the path of the dockerfile location.

This allows for instances where the Dockerfile is at the root of the context, but not in the root of the project. It also allows the existing use case where the context is the project root and with an independent path to the dockerfile
