### PR TITLE
Support the `GOOGLE_COMPUTE_REGION` config parameter [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ orb_promotion_filters: &orb_promotion_filters
 orbs:
   orb-tools: circleci/orb-tools@9.0.0
   gcp-gke: circleci/gcp-gke@<<pipeline.parameters.dev-orb-version>>
-  gcp-gcr: circleci/gcp-gcr@0.8.0
+  gcp-gcr: circleci/gcp-gcr@0.13.0
   kubernetes: circleci/kubernetes@0.11.0
 
 parameters:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -6,5 +6,5 @@ display:
 
 orbs:
   gcloud: circleci/gcp-cli@2.1.0
-  gcr: circleci/gcp-gcr@0.8.0
+  gcr: circleci/gcp-gcr@0.13.0
   k8s: circleci/kubernetes@0.11.0

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -5,6 +5,6 @@ display:
   source_url: https://github.com/circleci-public/gcp-gke-orb
 
 orbs:
-  gcloud: circleci/gcp-cli@1.8.3
+  gcloud: circleci/gcp-cli@2.1.0
   gcr: circleci/gcp-gcr@0.8.0
   k8s: circleci/kubernetes@0.11.0

--- a/src/commands/create-cluster.yml
+++ b/src/commands/create-cluster.yml
@@ -23,6 +23,10 @@ parameters:
     description: The Google compute zone to connect with via the gcloud CLI
     type: env_var_name
     default: GOOGLE_COMPUTE_ZONE
+  google-compute-region:
+    description: The Google compute region to connect with via the gcloud CLI
+    type: env_var_name
+    default: GOOGLE_COMPUTE_REGION
   additional-args:
     description: Additional arguments to "gcloud container clusters create"
     type: string
@@ -52,6 +56,7 @@ steps:
             gcloud-service-key: <<parameters.gcloud-service-key>>
             google-project-id: <<parameters.google-project-id>>
             google-compute-zone: <<parameters.google-compute-zone>>
+            google-compute-region: <<parameters.google-compute-region>>
   - run:
       name: Create GKE cluster
       command: |

--- a/src/commands/create-node-pool.yml
+++ b/src/commands/create-node-pool.yml
@@ -27,6 +27,10 @@ parameters:
     description: The Google compute zone to connect with via the gcloud CLI
     type: env_var_name
     default: GOOGLE_COMPUTE_ZONE
+  google-compute-region:
+    description: The Google compute region to connect with via the gcloud CLI
+    type: env_var_name
+    default: GOOGLE_COMPUTE_REGION
   additional-args:
     description: Additional arguments to "gcloud container node-pools create"
     type: string
@@ -47,6 +51,7 @@ steps:
             gcloud-service-key: <<parameters.gcloud-service-key>>
             google-project-id: <<parameters.google-project-id>>
             google-compute-zone: <<parameters.google-compute-zone>>
+            google-compute-region: <<parameters.google-compute-region>>
   - run:
       name: Create node pool
       command: |

--- a/src/commands/delete-cluster.yml
+++ b/src/commands/delete-cluster.yml
@@ -23,6 +23,10 @@ parameters:
     description: The Google compute zone to connect with via the gcloud CLI
     type: env_var_name
     default: GOOGLE_COMPUTE_ZONE
+  google-compute-region:
+    description: The Google compute region to connect with via the gcloud CLI
+    type: env_var_name
+    default: GOOGLE_COMPUTE_REGION
   additional-args:
     description: Additional arguments to "gcloud container clusters delete"
     type: string
@@ -43,6 +47,7 @@ steps:
             gcloud-service-key: <<parameters.gcloud-service-key>>
             google-project-id: <<parameters.google-project-id>>
             google-compute-zone: <<parameters.google-compute-zone>>
+            google-compute-region: <<parameters.google-compute-region>>
   - run:
       name: Delete GKE cluster
       command: |

--- a/src/commands/delete-node-pool.yml
+++ b/src/commands/delete-node-pool.yml
@@ -27,6 +27,10 @@ parameters:
     description: The Google compute zone to connect with via the gcloud CLI
     type: env_var_name
     default: GOOGLE_COMPUTE_ZONE
+  google-compute-region:
+    description: The Google compute region to connect with via the gcloud CLI
+    type: env_var_name
+    default: GOOGLE_COMPUTE_REGION
   additional-args:
     description: Additional arguments to "gcloud container node-pools delete"
     type: string
@@ -47,6 +51,7 @@ steps:
             gcloud-service-key: <<parameters.gcloud-service-key>>
             google-project-id: <<parameters.google-project-id>>
             google-compute-zone: <<parameters.google-compute-zone>>
+            google-compute-region: <<parameters.google-compute-region>>
   - run:
       name: Delete node pool
       command: |

--- a/src/commands/update-kubeconfig-with-credentials.yml
+++ b/src/commands/update-kubeconfig-with-credentials.yml
@@ -24,6 +24,10 @@ parameters:
     description: The Google compute zone to connect with via the gcloud CLI
     type: env_var_name
     default: GOOGLE_COMPUTE_ZONE
+  google-compute-region:
+    description: The Google compute region to connect with via the gcloud CLI
+    type: env_var_name
+    default: GOOGLE_COMPUTE_REGION
   install-kubectl:
     description: >
       Whether to install kubectl
@@ -39,6 +43,7 @@ steps:
             gcloud-service-key: <<parameters.gcloud-service-key>>
             google-project-id: <<parameters.google-project-id>>
             google-compute-zone: <<parameters.google-compute-zone>>
+            google-compute-region: <<parameters.google-compute-region>>
   - when:
       condition: <<parameters.install-kubectl>>
       steps:

--- a/src/jobs/create-cluster.yml
+++ b/src/jobs/create-cluster.yml
@@ -25,6 +25,10 @@ parameters:
     description: The Google compute zone to connect with via the gcloud CLI
     type: env_var_name
     default: GOOGLE_COMPUTE_ZONE
+  google-compute-region:
+    description: The Google compute region to connect with via the gcloud CLI
+    type: env_var_name
+    default: GOOGLE_COMPUTE_REGION
   additional-args:
     description: Additional arguments to "gcloud container clusters create"
     type: string
@@ -49,5 +53,6 @@ steps:
       gcloud-service-key: <<parameters.gcloud-service-key>>
       google-project-id: <<parameters.google-project-id>>
       google-compute-zone: <<parameters.google-compute-zone>>
+      google-compute-region: <<parameters.google-compute-region>>
       additional-args: <<parameters.additional-args>>
       no-output-timeout: <<parameters.no-output-timeout>>

--- a/src/jobs/create-node-pool.yml
+++ b/src/jobs/create-node-pool.yml
@@ -29,6 +29,10 @@ parameters:
     description: The Google compute zone to connect with via the gcloud CLI
     type: env_var_name
     default: GOOGLE_COMPUTE_ZONE
+  google-compute-region:
+    description: The Google compute region to connect with via the gcloud CLI
+    type: env_var_name
+    default: GOOGLE_COMPUTE_REGION
   additional-args:
     description: Additional arguments to "gcloud container node-pools create"
     type: string
@@ -53,5 +57,6 @@ steps:
       gcloud-service-key: <<parameters.gcloud-service-key>>
       google-project-id: <<parameters.google-project-id>>
       google-compute-zone: <<parameters.google-compute-zone>>
+      google-compute-region: <<parameters.google-compute-region>>
       additional-args: <<parameters.additional-args>>
       no-output-timeout: <<parameters.no-output-timeout>>

--- a/src/jobs/delete-cluster.yml
+++ b/src/jobs/delete-cluster.yml
@@ -25,6 +25,10 @@ parameters:
     description: The Google compute zone to connect with via the gcloud CLI
     type: env_var_name
     default: GOOGLE_COMPUTE_ZONE
+  google-compute-region:
+    description: The Google compute region to connect with via the gcloud CLI
+    type: env_var_name
+    default: GOOGLE_COMPUTE_REGION
   additional-args:
     description: Additional arguments to "gcloud container clusters delete"
     type: string
@@ -48,5 +52,6 @@ steps:
       gcloud-service-key: <<parameters.gcloud-service-key>>
       google-project-id: <<parameters.google-project-id>>
       google-compute-zone: <<parameters.google-compute-zone>>
+      google-compute-region: <<parameters.google-compute-region>>
       additional-args: <<parameters.additional-args>>
       no-output-timeout: <<parameters.no-output-timeout>>

--- a/src/jobs/delete-node-pool.yml
+++ b/src/jobs/delete-node-pool.yml
@@ -29,6 +29,10 @@ parameters:
     description: The Google compute zone to connect with via the gcloud CLI
     type: env_var_name
     default: GOOGLE_COMPUTE_ZONE
+  google-compute-region:
+    description: The Google compute region to connect with via the gcloud CLI
+    type: env_var_name
+    default: GOOGLE_COMPUTE_REGION
   additional-args:
     description: Additional arguments to "gcloud container node-pools delete"
     type: string
@@ -53,5 +57,6 @@ steps:
       gcloud-service-key: <<parameters.gcloud-service-key>>
       google-project-id: <<parameters.google-project-id>>
       google-compute-zone: <<parameters.google-compute-zone>>
+      google-compute-region: <<parameters.google-compute-region>>
       additional-args: <<parameters.additional-args>>
       no-output-timeout: <<parameters.no-output-timeout>>

--- a/src/jobs/publish-and-rollout-image.yml
+++ b/src/jobs/publish-and-rollout-image.yml
@@ -23,6 +23,10 @@ parameters:
     description: The Google compute zone to connect with via the gcloud CLI
     type: env_var_name
     default: GOOGLE_COMPUTE_ZONE
+  google-compute-region:
+    description: The Google compute region to connect with via the gcloud CLI
+    type: env_var_name
+    default: GOOGLE_COMPUTE_REGION
   registry-url:
     description: The GCR registry URL from ['', us, eu, asia].gcr.io
     type: string
@@ -88,6 +92,7 @@ steps:
       gcloud-service-key: <<parameters.gcloud-service-key>>
       google-project-id: <<parameters.google-project-id>>
       google-compute-zone: <<parameters.google-compute-zone>>
+      google-compute-region: <<parameters.google-compute-region>>
   - install
   - gcr/build-image:
       registry-url: <<parameters.registry-url>>


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:
Upgrade `gcp-cli` and `gcp-gcr` orbs versions to latest to support the `google-compute-region` parameter.

## Motivation:
GKE regional clusters require the region parameter rather than zone. Following CircleCI-Public/gcp-gcr-orb#45, users using this orb would be able to work with regional clusters as well.

 **Closes Issues:**
-  https://github.com/CircleCI-Public/gcp-gke-orb/issues/9

## Checklist:

- [x] All new jobs, commands, executors, parameters have descriptions.
- [x] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.