### PR TITLE
feat(create-cluster): Add parameter for Autopilot [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ workflows:
       - gcp-gke/create-cluster:
           name: create-cluster-linux
           cluster: my-cluster
-      - gcp-gke/create-autopilot-cluster:
+      - gcp-gke/create-cluster:
           name: create-autopilot-cluster-linux
           cluster: my-autopilot-cluster
       - gcp-gke/create-cluster:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,9 @@ workflows:
       - gcp-gke/create-cluster:
           name: create-cluster-linux
           cluster: my-cluster
+      - gcp-gke/create-autopilot-cluster:
+          name: create-autopilot-cluster-linux
+          cluster: my-autopilot-cluster
       - gcp-gke/create-cluster:
           name: create-cluster-windows
           cluster: my-cluster-windows
@@ -188,6 +191,11 @@ workflows:
           cluster: my-cluster
           requires:
             - gcp-gke/publish-and-rollout-image
+      - gcp-gke/delete-cluster:
+          name: delete-autopilot-cluster-linux
+          cluster: my-autopilot-cluster
+          requires:
+            - create-autopilot-cluster-linux
       - gcp-gke/delete-cluster:
           name: delete-cluster-windows
           cluster: my-cluster-windows

--- a/src/commands/create-cluster.yml
+++ b/src/commands/create-cluster.yml
@@ -68,9 +68,9 @@ steps:
         GKE_PARAM_CLUSTER_NAME: <<parameters.cluster >>
       command: |
         if [ "$GKE_PARAM_ENABLE_AUTOPILOT" = "0" ]; then
-          PARAM_CLUSTER_CREATE = "create"
+          export PARAM_CLUSTER_CREATE="create"
         else
-          PARAM_CLUSTER_CREATE = "create-auto"
+          export PARAM_CLUSTER_CREATE="create-auto"
         fi
         gcloud container clusters "$PARAM_CLUSTER_CREATE" "$GKE_PARAM_CLUSTER_NAME" <<parameters.additional-args>>
       no_output_timeout: <<parameters.no-output-timeout>>

--- a/src/commands/create-cluster.yml
+++ b/src/commands/create-cluster.yml
@@ -2,6 +2,10 @@ description: >
   Creates a GKE cluster.
 
 parameters:
+  autopilot:
+    description: Create your GKE cluster in Autopilot mode. Autopilot clusters are managed and pre-configured with an optimised, production-ready cluster configuration.
+    type: boolean
+    default: false
   cluster:
     description: >
       Name of the GKE cluster to be created
@@ -59,6 +63,14 @@ steps:
             google-compute-region: <<parameters.google-compute-region>>
   - run:
       name: Create GKE cluster
+      environment:
+        GKE_PARAM_ENABLE_AUTOPILOT: <<parameters.autopilot>>
+        GKE_PARAM_CLUSTER_NAME: <<parameters.cluster >>
       command: |
-        gcloud container clusters create <<parameters.cluster >> <<parameters.additional-args>>
+        if [ "$GKE_PARAM_ENABLE_AUTOPILOT" = "0" ]; then
+          PARAM_CLUSTER_CREATE = "create"
+        else
+          PARAM_CLUSTER_CREATE = "create-auto"
+        fi
+        gcloud container clusters "$PARAM_CLUSTER_CREATE" "$GKE_PARAM_CLUSTER_NAME" <<parameters.additional-args>>
       no_output_timeout: <<parameters.no-output-timeout>>


### PR DESCRIPTION
Create-Cluster command extended with a new parameter to allow for creating clusters in Autopilot mode, a new managed cluster offering.

Test added to create and remove the cluster.