### PR TITLE
Accept region and zone for cluster credentials

### DIFF
--- a/src/commands/update-kubeconfig-with-credentials.yml
+++ b/src/commands/update-kubeconfig-with-credentials.yml
@@ -51,4 +51,9 @@ steps:
   - run:
       name: Update kubeconfig with cluster credentials
       command: |
-        gcloud container clusters get-credentials <<parameters.cluster>>
+        if [[ -z "<< parameters.google-compute-zone >>" ]]; then
+          export CLUSTER_LOCATION="--zone << parameters.google-compute-zone >>"
+        else
+          export CLUSTER_LOCATION="--region << parameters.google-compute-region >>"
+        fi   
+        gcloud container clusters get-credentials <<parameters.cluster>> "$CLUSTER_LOCATION"


### PR DESCRIPTION
Currently the command `update-kubeconfig-with-credentials` throws errors:

```bash
ERROR: (gcloud.container.clusters.get-credentials) One of [--zone, --region] must be supplied: Please specify location.
```

As it requires a `zone` or `region` parameter which is never passed. This can be hacked to work via the following:

```yaml
      - gcp-gke/update-kubeconfig-with-credentials:
          perform-login: true
          install-kubectl: true
          cluster: "my-cluster --region $GOOGLE_COMPUTE_REGION"
```