### PR TITLE
Add `install-gcloud` param for kubeconfig updates

### DIFF
--- a/src/commands/update-kubeconfig-with-credentials.yml
+++ b/src/commands/update-kubeconfig-with-credentials.yml
@@ -7,6 +7,11 @@ parameters:
     description: >
       The name of the cluster for which to create a kubeconfig entry.
     type: string
+  install-gcloud:
+    description: >
+      Whether to install the gcloud CLI
+    type: boolean
+    default: true
   perform-login:
     description: >
       Whether to perform a login with the gcloud CLI.
@@ -35,7 +40,10 @@ parameters:
     default: false
 
 steps:
-  - gcloud/install
+  - when:
+      condition: <<parameters.install-gcloud>>
+      steps:
+        - gcloud/install
   - when:
       condition: <<parameters.perform-login>>
       steps:


### PR DESCRIPTION
Allows the `gcloud/install` step on the `update-kubeconfig-with-credentials` command to be skipped. Defaults to `true` to maintain backwards compatibility.