### PR TITLE
chore: migrate to orb tools 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ workflows:
       - orb-tools/pack:
           filters: *filters
       - orb-tools/review:
+          exclude: RC009
           filters: *filters
       - shellcheck/check:
           filters: *filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,233 +1,33 @@
 version: 2.1
-
-orb_promotion_filters: &orb_promotion_filters
-  branches:
-    ignore: /.*/
-  tags:
-    only: /^(major|minor|patch)-release-v\d+\.\d+\.\d+$/
-
+setup: true
 orbs:
-  orb-tools: circleci/orb-tools@9.0.0
-  gcp-gke: circleci/gcp-gke@<<pipeline.parameters.dev-orb-version>>
-  gcp-gcr: circleci/gcp-gcr@0.13.0
-  kubernetes: circleci/kubernetes@0.11.0
+  orb-tools: circleci/orb-tools@11.3
+  shellcheck: circleci/shellcheck@3.1
 
-parameters:
-  run-integration-tests:
-    type: boolean
-    default: false
-  dev-orb-version:
-    type: string
-    default: "dev:alpha"
-
-jobs:
-  create-deployment-linux:
-    parameters:
-      cluster-name:
-        type: string
-      docker-image-name:
-        type: string
-      full-image-name:
-        type: string
-      version-info:
-        type: string
-    executor: gcp-gke/default
-    steps:
-      - setup_remote_docker
-      - checkout
-      - gcp-gke/update-kubeconfig-with-credentials:
-          cluster: <<parameters.cluster-name>>
-          perform-login: true
-          install-kubectl: true
-      - run:
-          name: Create deployment manifest
-          command: |
-            # Replace the placeholders in the manifest with the intended values.
-            BUILD_DATE=$(date '+%Y%m%d%H%M%S')
-            cat tests/demoapp/deployment.yaml.template |\
-               sed "s|DOCKER_IMAGE_NAME|<< parameters.full-image-name >>:$CIRCLE_SHA1|\
-                g;s|BUILD_DATE_VALUE|$BUILD_DATE|g;s|VERSION_INFO_VALUE|\
-                << parameters.version-info >>|g" > tests/demoapp/deployment.yaml
-      - gcp-gcr/gcr-auth
-      - gcp-gcr/build-image:
-          image: << parameters.docker-image-name >>
-          tag: $CIRCLE_SHA1
-          dockerfile: Dockerfile
-          path: /home/circleci/project/tests/demoapp
-          docker-context: /home/circleci/project/tests/demoapp
-      - gcp-gcr/push-image:
-          image: << parameters.docker-image-name >>
-          tag: $CIRCLE_SHA1
-      - kubernetes/create-or-update-resource:
-          resource-file-path: "tests/demoapp/deployment.yaml"
-          get-rollout-status: true
-          resource-name: deployment/demoapp
-
-  create-deployment-windows:
-    parameters:
-      cluster-name:
-        type: string
-    executor: gcp-gke/default
-    steps:
-      - setup_remote_docker
-      - checkout
-      - gcp-gke/update-kubeconfig-with-credentials:
-          cluster: <<parameters.cluster-name>>
-          perform-login: true
-          install-kubectl: true
-      - run:
-          name: Check cluster initialization
-          command: |
-            kubectl get mutatingwebhookconfigurations
-      - kubernetes/create-or-update-resource:
-          resource-file-path: "tests/windows-iis/deployment.yaml"
-          resource-name: "deployment/iis"
-          get-rollout-status: true
-      - run:
-          name: Expose deployment via a service
-          command: |
-            kubectl expose deployment iis --type=LoadBalancer --name=iis
-      - run:
-          name: Validate service
-          command: |
-            kubectl get services
-            sleep 30
-            for attempt in {1..20}; do
-              EXTERNAL_IP=$(kubectl get service iis | awk '{print $4}' | tail -n1)
-              echo "Checking external IP: ${EXTERNAL_IP}"
-              if [ -n "${EXTERNAL_IP}" ] && [ -z $(echo "${EXTERNAL_IP}" | grep "pending") ]; then
-                break
-              fi
-              echo "Waiting for external IP to be ready: ${EXTERNAL_IP}"
-              sleep 10
-            done
-            sleep 180
-            curl -s --retry 10 "http://$EXTERNAL_IP" | grep "IIS Windows Server"
-      - kubernetes/delete-resource:
-          resource-types: "deployment,service"
-          resource-names: "iis"
-          now: true
-          wait: true
+filters: &filters
+  tags:
+    only: /.*/
 
 workflows:
-  lint_pack-validate_publish-dev:
-    unless: << pipeline.parameters.run-integration-tests >>
+  lint-pack:
     jobs:
-      - orb-tools/lint
-
+      - orb-tools/lint:
+          filters: *filters
       - orb-tools/pack:
-          requires:
-            - orb-tools/lint
-
-      - orb-tools/publish-dev:
+          filters: *filters
+      - orb-tools/review:
+          filters: *filters
+      - shellcheck/check:
+          filters: *filters
+      - orb-tools/publish:
           orb-name: circleci/gcp-gke
+          vcs-type: << pipeline.project.type >>
+          requires:
+            [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           context: orb-publisher
-          requires:
-            - orb-tools/pack
-
-      - orb-tools/trigger-integration-tests-workflow:
-          name: trigger-integration-dev
-          context: orb-publishing
-          requires:
-            - orb-tools/publish-dev
-
-  integration-tests_prod-release:
-    when: << pipeline.parameters.run-integration-tests >>
-    jobs:
-      - gcp-gke/create-cluster:
-          name: create-cluster-linux
-          cluster: my-cluster
-      - gcp-gke/create-cluster:
-          name: create-autopilot-cluster-linux
-          cluster: my-autopilot-cluster
-      - gcp-gke/create-cluster:
-          name: create-cluster-windows
-          cluster: my-cluster-windows
-          additional-args: "--cluster-version=1.20 --enable-ip-alias --num-nodes=1"
-      - gcp-gke/create-node-pool:
-          name: create-node-pool-windows
-          node-pool: my-pool-windows
-          cluster: my-cluster-windows
-          additional-args: "--image-type=WINDOWS_SAC --no-enable-autoupgrade --machine-type=n1-standard-2 --num-nodes=1"
-          requires:
-            - create-cluster-windows
-      - create-deployment-linux:
-          requires:
-            - create-cluster-linux
-          cluster-name: my-cluster
-          full-image-name: gcr.io/$GOOGLE_PROJECT_ID/my-image
-          docker-image-name: my-image
-          version-info: $CIRCLE_SHA1
-      - create-deployment-windows:
-          requires:
-            - create-node-pool-windows
-          cluster-name: my-cluster-windows
-      - gcp-gke/publish-and-rollout-image:
-          post-steps:
-            - kubernetes/get-rollout-status:
-                resource-name: deployment/demoapp
-                watch-rollout-status: true
-                watch-timeout: 3m
-                namespace: default
-          requires:
-            - create-deployment-linux
-          cluster: my-cluster
-          deployment: demoapp
-          container: app
-          image: my-image
-          tag: $CIRCLE_SHA1
-          namespace: default
-          dockerfile-name: Dockerfile
-          dockerfile-dir: /home/circleci/project/tests/demoapp
-          docker-context: /home/circleci/project/tests/demoapp
-      - gcp-gke/delete-node-pool:
-          name: delete-node-pool-windows
-          node-pool: my-pool-windows
-          cluster: my-cluster-windows
-          requires:
-            - create-deployment-windows
-      - gcp-gke/delete-cluster:
-          name: delete-cluster-linux
-          cluster: my-cluster
-          requires:
-            - gcp-gke/publish-and-rollout-image
-      - gcp-gke/delete-cluster:
-          name: delete-autopilot-cluster-linux
-          cluster: my-autopilot-cluster
-          requires:
-            - create-autopilot-cluster-linux
-      - gcp-gke/delete-cluster:
-          name: delete-cluster-windows
-          cluster: my-cluster-windows
-          requires:
-            - delete-node-pool-windows
-      - orb-tools/dev-promote-prod-from-commit-subject:
-          orb-name: circleci/gcp-gke
-          context: orb-publisher
-          add-pr-comment: true
-          bot-user: orb-publisher
-          bot-token-variable: GHI_TOKEN
-          publish-version-tag: false
-          fail-if-semver-not-indicated: false
-          requires:
-            - delete-cluster-linux
-            - delete-cluster-windows
-          filters:
-            branches:
-              only: master
-
-  tag-triggered-orb-publishing:
-    unless: << pipeline.parameters.run-integration-tests >>
-    jobs:
-      - hold-for-approval:
-          type: approval
-          filters: *orb_promotion_filters
-      - orb-tools/dev-promote-prod-from-git-tag:
-          context: orb-publisher
-          orb-name: circleci/gcp-gke
-          add-pr-comment: true
-          bot-user: orb-publisher
-          bot-token-variable: GHI_TOKEN
-          requires:
-            - hold-for-approval
-          filters: *orb_promotion_filters
+          filters: *filters
+      - orb-tools/continue:
+          pipeline-number: << pipeline.number >>
+          vcs-type: << pipeline.project.type >>
+          requires: [orb-tools/publish]
+          filters: *filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -109,7 +109,7 @@ workflows:
       - gcp-gke/create-cluster:
           name: create-cluster-windows
           cluster: my-cluster-windows
-          additional-args: "--cluster-version=1.20 --enable-ip-alias --num-nodes=1"
+          additional-args: "--cluster-version=1.24.2-gke.1900 --enable-ip-alias --num-nodes=1"
       - gcp-gke/create-node-pool:
           name: create-node-pool-windows
           node-pool: my-pool-windows

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -109,7 +109,7 @@ workflows:
       - gcp-gke/create-cluster:
           name: create-cluster-windows
           cluster: my-cluster-windows
-          additional-args: "--cluster-version=1.24.2-gke.1900 --enable-ip-alias --num-nodes=1"
+          additional-args: "--cluster-version=1.22.12-gke.2300 --enable-ip-alias --num-nodes=1"
       - gcp-gke/create-node-pool:
           name: create-node-pool-windows
           node-pool: my-pool-windows

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -103,13 +103,16 @@ workflows:
       - gcp-gke/create-cluster:
           name: create-cluster-linux
           cluster: my-cluster
+          filters: *filters
       - gcp-gke/create-cluster:
           name: create-autopilot-cluster-linux
           cluster: my-autopilot-cluster
+          filters: *filters
       - gcp-gke/create-cluster:
           name: create-cluster-windows
           cluster: my-cluster-windows
           additional-args: "--cluster-version=1.22.12-gke.2300 --enable-ip-alias --num-nodes=1"
+          filters: *filters
       - gcp-gke/create-node-pool:
           name: create-node-pool-windows
           node-pool: my-pool-windows
@@ -117,6 +120,7 @@ workflows:
           additional-args: "--image-type=WINDOWS_LTSC_CONTAINERD --no-enable-autoupgrade --machine-type=n1-standard-2 --num-nodes=1"
           requires:
             - create-cluster-windows
+          filters: *filters
       - create-deployment-linux:
           requires:
             - create-cluster-linux
@@ -124,10 +128,12 @@ workflows:
           full-image-name: gcr.io/$GOOGLE_PROJECT_ID/my-image
           docker-image-name: my-image
           version-info: $CIRCLE_SHA1
+          filters: *filters
       - create-deployment-windows:
           requires:
             - create-node-pool-windows
           cluster-name: my-cluster-windows
+          filters: *filters
       - gcp-gke/publish-and-rollout-image:
           post-steps:
             - kubernetes/get-rollout-status:
@@ -146,27 +152,32 @@ workflows:
           dockerfile-name: Dockerfile
           dockerfile-dir: /home/circleci/project/tests/demoapp
           docker-context: /home/circleci/project/tests/demoapp
+          filters: *filters
       - gcp-gke/delete-node-pool:
           name: delete-node-pool-windows
           node-pool: my-pool-windows
           cluster: my-cluster-windows
           requires:
             - create-deployment-windows
+          filters: *filters
       - gcp-gke/delete-cluster:
           name: delete-cluster-linux
           cluster: my-cluster
           requires:
             - gcp-gke/publish-and-rollout-image
+          filters: *filters
       - gcp-gke/delete-cluster:
           name: delete-autopilot-cluster-linux
           cluster: my-autopilot-cluster
           requires:
             - create-autopilot-cluster-linux
+          filters: *filters
       - gcp-gke/delete-cluster:
           name: delete-cluster-windows
           cluster: my-cluster-windows
           requires:
             - delete-node-pool-windows
+          filters: *filters
       - orb-tools/pack:
           filters: *filters
       - orb-tools/publish:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,0 +1,185 @@
+version: 2.1
+orbs:
+  gcp-gke: circleci/gcp-gke@dev:<<pipeline.git.revision>>
+  orb-tools: circleci/orb-tools@11.3
+  gcp-gcr: circleci/gcp-gcr@0.15
+  kubernetes: circleci/kubernetes@0.11.0
+
+filters: &filters
+  tags:
+    only: /.*/
+
+jobs:
+  create-deployment-linux:
+    parameters:
+      cluster-name:
+        type: string
+      docker-image-name:
+        type: string
+      full-image-name:
+        type: string
+      version-info:
+        type: string
+    executor: gcp-gke/default
+    steps:
+      - setup_remote_docker
+      - checkout
+      - gcp-gke/update-kubeconfig-with-credentials:
+          cluster: <<parameters.cluster-name>>
+          perform-login: true
+          install-kubectl: true
+      - run:
+          name: Create deployment manifest
+          command: |
+            # Replace the placeholders in the manifest with the intended values.
+            BUILD_DATE=$(date '+%Y%m%d%H%M%S')
+            cat tests/demoapp/deployment.yaml.template |\
+               sed "s|DOCKER_IMAGE_NAME|<< parameters.full-image-name >>:$CIRCLE_SHA1|\
+                g;s|BUILD_DATE_VALUE|$BUILD_DATE|g;s|VERSION_INFO_VALUE|\
+                << parameters.version-info >>|g" > tests/demoapp/deployment.yaml
+      - gcp-gcr/gcr-auth
+      - gcp-gcr/build-image:
+          image: << parameters.docker-image-name >>
+          tag: $CIRCLE_SHA1
+          dockerfile: Dockerfile
+          path: /home/circleci/project/tests/demoapp
+          docker-context: /home/circleci/project/tests/demoapp
+      - gcp-gcr/push-image:
+          image: << parameters.docker-image-name >>
+          tag: $CIRCLE_SHA1
+      - kubernetes/create-or-update-resource:
+          resource-file-path: "tests/demoapp/deployment.yaml"
+          get-rollout-status: true
+          resource-name: deployment/demoapp
+  create-deployment-windows:
+    parameters:
+      cluster-name:
+        type: string
+    executor: gcp-gke/default
+    steps:
+      - setup_remote_docker
+      - checkout
+      - gcp-gke/update-kubeconfig-with-credentials:
+          cluster: <<parameters.cluster-name>>
+          perform-login: true
+          install-kubectl: true
+      - run:
+          name: Check cluster initialization
+          command: |
+            kubectl get mutatingwebhookconfigurations
+      - kubernetes/create-or-update-resource:
+          resource-file-path: "tests/windows-iis/deployment.yaml"
+          resource-name: "deployment/iis"
+          get-rollout-status: true
+      - run:
+          name: Expose deployment via a service
+          command: |
+            kubectl expose deployment iis --type=LoadBalancer --name=iis
+      - run:
+          name: Validate service
+          command: |
+            kubectl get services
+            sleep 30
+            for attempt in {1..20}; do
+              EXTERNAL_IP=$(kubectl get service iis | awk '{print $4}' | tail -n1)
+              echo "Checking external IP: ${EXTERNAL_IP}"
+              if [ -n "${EXTERNAL_IP}" ] && [ -z $(echo "${EXTERNAL_IP}" | grep "pending") ]; then
+                break
+              fi
+              echo "Waiting for external IP to be ready: ${EXTERNAL_IP}"
+              sleep 10
+            done
+            sleep 180
+            curl -s --retry 10 "http://$EXTERNAL_IP" | grep "IIS Windows Server"
+      - kubernetes/delete-resource:
+          resource-types: "deployment,service"
+          resource-names: "iis"
+          now: true
+          wait: true
+
+workflows:
+  test-deploy:
+    jobs:
+      - gcp-gke/create-cluster:
+          name: create-cluster-linux
+          cluster: my-cluster
+      - gcp-gke/create-cluster:
+          name: create-autopilot-cluster-linux
+          cluster: my-autopilot-cluster
+      - gcp-gke/create-cluster:
+          name: create-cluster-windows
+          cluster: my-cluster-windows
+          additional-args: "--cluster-version=1.20 --enable-ip-alias --num-nodes=1"
+      - gcp-gke/create-node-pool:
+          name: create-node-pool-windows
+          node-pool: my-pool-windows
+          cluster: my-cluster-windows
+          additional-args: "--image-type=WINDOWS_SAC --no-enable-autoupgrade --machine-type=n1-standard-2 --num-nodes=1"
+          requires:
+            - create-cluster-windows
+      - create-deployment-linux:
+          requires:
+            - create-cluster-linux
+          cluster-name: my-cluster
+          full-image-name: gcr.io/$GOOGLE_PROJECT_ID/my-image
+          docker-image-name: my-image
+          version-info: $CIRCLE_SHA1
+      - create-deployment-windows:
+          requires:
+            - create-node-pool-windows
+          cluster-name: my-cluster-windows
+      - gcp-gke/publish-and-rollout-image:
+          post-steps:
+            - kubernetes/get-rollout-status:
+                resource-name: deployment/demoapp
+                watch-rollout-status: true
+                watch-timeout: 3m
+                namespace: default
+          requires:
+            - create-deployment-linux
+          cluster: my-cluster
+          deployment: demoapp
+          container: app
+          image: my-image
+          tag: $CIRCLE_SHA1
+          namespace: default
+          dockerfile-name: Dockerfile
+          dockerfile-dir: /home/circleci/project/tests/demoapp
+          docker-context: /home/circleci/project/tests/demoapp
+      - gcp-gke/delete-node-pool:
+          name: delete-node-pool-windows
+          node-pool: my-pool-windows
+          cluster: my-cluster-windows
+          requires:
+            - create-deployment-windows
+      - gcp-gke/delete-cluster:
+          name: delete-cluster-linux
+          cluster: my-cluster
+          requires:
+            - gcp-gke/publish-and-rollout-image
+      - gcp-gke/delete-cluster:
+          name: delete-autopilot-cluster-linux
+          cluster: my-autopilot-cluster
+          requires:
+            - create-autopilot-cluster-linux
+      - gcp-gke/delete-cluster:
+          name: delete-cluster-windows
+          cluster: my-cluster-windows
+          requires:
+            - delete-node-pool-windows
+      - orb-tools/pack:
+          filters: *filters
+      - orb-tools/publish:
+          orb-name: circleci/gcp-gke
+          vcs-type: << pipeline.project.type >>
+          pub-type: production
+          requires:
+            - orb-tools/pack
+            - delete-cluster-linux
+            - delete-cluster-windows
+          context: orb-publisher
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -114,7 +114,7 @@ workflows:
           name: create-node-pool-windows
           node-pool: my-pool-windows
           cluster: my-cluster-windows
-          additional-args: "--image-type=WINDOWS_SAC --no-enable-autoupgrade --machine-type=n1-standard-2 --num-nodes=1"
+          additional-args: "--image-type=WINDOWS_LTSC_CONTAINERD --no-enable-autoupgrade --machine-type=n1-standard-2 --num-nodes=1"
           requires:
             - create-cluster-windows
       - create-deployment-linux:

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,6 @@
+extends: relaxed
+
+rules:
+    line-length:
+        max: 200
+        allow-non-breakable-inline-mappings: true

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,10 +1,10 @@
 version: 2.1
-description: Google Kubernetes Engine (GKE) Orb
+description: Easily manage your Google Kubernetes Engine (GKE) clusters and node pools.
 display:
   home_url: https://cloud.google.com/kubernetes-engine
   source_url: https://github.com/circleci-public/gcp-gke-orb
 
 orbs:
   gcloud: circleci/gcp-cli@2.1.0
-  gcr: circleci/gcp-gcr@0.13.0
+  gcr: circleci/gcp-gcr@0.15
   k8s: circleci/kubernetes@0.11.0


### PR DESCRIPTION
## Motivation

Modernize the orb's release process with Orb Tools 11.

## Changes

This PR replaces the old `config.yml` with the new found in the [Orb Template](https://github.com/CircleCI-Public/Orb-Template) and moves all integration tests to `test-deploy.yml`.