### PR TITLE
feat: add support for gcloud version on all jobs

### DIFF
--- a/src/jobs/create-cluster.yml
+++ b/src/jobs/create-cluster.yml
@@ -54,6 +54,11 @@ parameters:
     description: |
       Name of environment variable storing the Google compute region to set as
       default for the gcloud CLI.
+  gcloud_version:
+    type: string
+    default: latest
+    description: |
+      Version of gcloud CLI to install.
   # OIDC parameters
   use_oidc:
     type: boolean
@@ -92,6 +97,7 @@ parameters:
 
 steps:
   - gcp-cli/setup:
+      version: <<parameters.gcloud_version>>
       components: "gke-gcloud-auth-plugin kubectl"
       gcloud_service_key: <<parameters.gcloud_service_key>>
       google_project_id: <<parameters.google_project_id>>

--- a/src/jobs/create-node-pool.yml
+++ b/src/jobs/create-node-pool.yml
@@ -52,6 +52,11 @@ parameters:
     description: |
       Name of environment variable storing the Google compute region to set as
       default for the gcloud CLI.
+  gcloud_version:
+    type: string
+    default: latest
+    description: |
+      Version of gcloud CLI to install.
   # OIDC parameters
   use_oidc:
     type: boolean
@@ -90,6 +95,7 @@ parameters:
 
 steps:
   - gcp-cli/setup:
+      version: <<parameters.gcloud_version>>
       components: "gke-gcloud-auth-plugin kubectl"
       gcloud_service_key: <<parameters.gcloud_service_key>>
       google_project_id: <<parameters.google_project_id>>

--- a/src/jobs/delete-cluster.yml
+++ b/src/jobs/delete-cluster.yml
@@ -48,6 +48,11 @@ parameters:
     description: |
       Name of environment variable storing the Google compute region to set as
       default for the gcloud CLI.
+  gcloud_version:
+    type: string
+    default: latest
+    description: |
+      Version of gcloud CLI to install.
   # OIDC parameters
   use_oidc:
     type: boolean
@@ -86,6 +91,7 @@ parameters:
 
 steps:
   - gcp-cli/setup:
+      version: <<parameters.gcloud_version>>
       components: "gke-gcloud-auth-plugin kubectl"
       gcloud_service_key: <<parameters.gcloud_service_key>>
       google_project_id: <<parameters.google_project_id>>

--- a/src/jobs/delete-node-pool.yml
+++ b/src/jobs/delete-node-pool.yml
@@ -52,6 +52,11 @@ parameters:
     description: |
       Name of environment variable storing the Google compute region to set as
       default for the gcloud CLI.
+  gcloud_version:
+    type: string
+    default: latest
+    description: |
+      Version of gcloud CLI to install.
   # OIDC parameters
   use_oidc:
     type: boolean
@@ -90,6 +95,7 @@ parameters:
 
 steps:
   - gcp-cli/setup:
+      version: <<parameters.gcloud_version>>
       components: "gke-gcloud-auth-plugin kubectl"
       gcloud_service_key: <<parameters.gcloud_service_key>>
       google_project_id: <<parameters.google_project_id>>

--- a/src/jobs/publish-and-rollout-image.yml
+++ b/src/jobs/publish-and-rollout-image.yml
@@ -99,6 +99,11 @@ parameters:
     description: |
       Name of environment variable storing the Google compute region to set as
       default for the gcloud CLI.
+  gcloud_version:
+    type: string
+    default: latest
+    description: |
+      Version of gcloud CLI to install.
   # OIDC parameters
   use_oidc:
     type: boolean
@@ -150,6 +155,7 @@ steps:
                 - setup_remote_docker
   - checkout
   - gcp-cli/setup:
+      version: <<parameters.gcloud_version>>
       components: "gke-gcloud-auth-plugin kubectl"
       gcloud_service_key: <<parameters.gcloud_service_key>>
       google_project_id: <<parameters.google_project_id>>


### PR DESCRIPTION
All jobs rely on the gcp-cli/setup command to install the gcloud sdk as part of the job steps but it's not possible to define the gcloud version to install.

This PR allows the user to set the gcloud version to install.