### PR TITLE
feat(rollout-image): update field to be able to set the workload type

### DIFF
--- a/src/commands/rollout-image.yml
+++ b/src/commands/rollout-image.yml
@@ -30,7 +30,7 @@ parameters:
   workload_type:
     default: "deployment"
     description: |
-      Workload type to rollout image. 
+      Workload type to rollout image.
       Must be "pod", "replicationcontroller", "deployment", "daemonset", "statefulset", "cronjob", or "replicaset".
     enum: ["pod", "replicationcontroller", "deployment", "daemonset", "statefulset", "cronjob", "replicaset"]
     type: enum

--- a/src/commands/rollout-image.yml
+++ b/src/commands/rollout-image.yml
@@ -30,10 +30,10 @@ parameters:
   workload_type:
     default: "deployment"
     description: |
-      Workload type to rollout. 
-      Possible resources include (case insensitive):
-      pod (po), replicationcontroller (rc), deployment (deploy), daemonset (ds), statefulset (sts), cronjob (cj), replicaset (rs)
-    type: string
+      Workload type to rollout image. 
+      Must be "pod", "replicationcontroller", "deployment", "daemonset", "statefulset", "cronjob", or "replicaset".
+    enum: ["pod", "replicationcontroller", "deployment", "daemonset", "statefulset", "cronjob", "replicaset"]
+    type: enum
 
 steps:
   - run:

--- a/src/commands/rollout-image.yml
+++ b/src/commands/rollout-image.yml
@@ -27,6 +27,13 @@ parameters:
       If server strategy, submit server-side request without persisting the resource.
     type: enum
     enum: ["none", "server", "client"]
+  workload_type:
+    default: "deployment"
+    description: |
+      Workload type to rollout. 
+      Possible resources include (case insensitive):
+      pod (po), replicationcontroller (rc), deployment (deploy), daemonset (ds), statefulset (sts), cronjob (cj), replicaset (rs)
+    type: string
 
 steps:
   - run:
@@ -38,5 +45,6 @@ steps:
         ORB_EVAL_CONTAINER: << parameters.container >>
         ORB_EVAL_IMAGE: << parameters.image >>
         ORB_EVAL_TAG: << parameters.tag >>
+        ORB_EVAL_WORKLOAD_TYPE: << parameters.workload_type >>
         ORB_SCRIPT_UTILS: <<include(scripts/utils.sh)>>
       command: <<include(scripts/rollout-image.sh)>>

--- a/src/jobs/publish-and-rollout-image.yml
+++ b/src/jobs/publish-and-rollout-image.yml
@@ -1,4 +1,3 @@
-
 description: "Update cluster with new Docker image."
 
 executor: <<parameters.executor>>
@@ -142,7 +141,7 @@ parameters:
   workload_type:
     default: "deployment"
     description: |
-      Workload type to rollout image. 
+      Workload type to rollout image.
       Must be "pod", "replicationcontroller", "deployment", "daemonset", "statefulset", "cronjob", or "replicaset".
     enum: ["pod", "replicationcontroller", "deployment", "daemonset", "statefulset", "cronjob", "replicaset"]
     type: enum
@@ -151,15 +150,15 @@ steps:
   - when:
       condition: <<parameters.use_remote_docker>>
       steps:
-          - when:
-              condition: <<parameters.remote_docker_version>>
-              steps:
-                - setup_remote_docker:
-                    version: <<parameters.remote_docker_version>>
-          - unless:
-              condition: <<parameters.remote_docker_version>>
-              steps:
-                - setup_remote_docker
+        - when:
+            condition: <<parameters.remote_docker_version>>
+            steps:
+              - setup_remote_docker:
+                  version: <<parameters.remote_docker_version>>
+        - unless:
+            condition: <<parameters.remote_docker_version>>
+            steps:
+              - setup_remote_docker
   - checkout
   - gcp-cli/setup:
       version: <<parameters.gcloud_version>>

--- a/src/jobs/publish-and-rollout-image.yml
+++ b/src/jobs/publish-and-rollout-image.yml
@@ -143,9 +143,9 @@ parameters:
     default: "deployment"
     description: |
       Workload type to rollout image. 
-      Possible resources include (case insensitive):
-      pod (po), replicationcontroller (rc), deployment (deploy), daemonset (ds), statefulset (sts), cronjob (cj), replicaset (rs)
-    type: string
+      Must be "pod", "replicationcontroller", "deployment", "daemonset", "statefulset", "cronjob", or "replicaset".
+    enum: ["pod", "replicationcontroller", "deployment", "daemonset", "statefulset", "cronjob", "replicaset"]
+    type: enum
 
 steps:
   - when:

--- a/src/jobs/publish-and-rollout-image.yml
+++ b/src/jobs/publish-and-rollout-image.yml
@@ -139,6 +139,13 @@ parameters:
     description: |
       Output location of OIDC credentials.
       Required if "use_oidc" is set to true.
+  workload_type:
+    default: "deployment"
+    description: |
+      Workload type to rollout image. 
+      Possible resources include (case insensitive):
+      pod (po), replicationcontroller (rc), deployment (deploy), daemonset (ds), statefulset (sts), cronjob (cj), replicaset (rs)
+    type: string
 
 steps:
   - when:
@@ -199,3 +206,4 @@ steps:
       tag: "<<parameters.tag>>"
       namespace: "<<parameters.namespace>>"
       dry_run: "<<parameters.dry_run>>"
+      workload_type: "<<parameters.workload_type>>"

--- a/src/scripts/rollout-image.sh
+++ b/src/scripts/rollout-image.sh
@@ -12,5 +12,5 @@ build_args=(
 
 set -x
 # shellcheck disable=SC2048,SC2086 # We want word splitting here.
-kubectl set image deployment "$ORB_EVAL_DEPLOYMENT" "$ORB_EVAL_CONTAINER"="$ORB_EVAL_IMAGE":"$ORB_EVAL_TAG" ${build_args[*]}
+kubectl set image "$ORB_EVAL_WORKLOAD_TYPE" "$ORB_EVAL_DEPLOYMENT" "$ORB_EVAL_CONTAINER"="$ORB_EVAL_IMAGE":"$ORB_EVAL_TAG" ${build_args[*]}
 set +x


### PR DESCRIPTION
The main motivation is to be able to set an image to a StatefulSet workload. This way we can use the same configuration between Deployment and StatefulSet by just providing one more field.
While this change makes the deployment parameter a bit strange since the name doesn't really match if the workload type isn't Deployment, for the sake of existing users and configurations will be kept.
The default value will still be _deployment_ to avoid any necessary changes for those that don't have the need to set a different workload type.