### PR TITLE
feat(registry): add support to artifact registry

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -5,5 +5,5 @@ display:
   source_url: https://github.com/circleci-public/gcp-gke-orb
 
 orbs:
-  gcp-cli: circleci/gcp-cli@3.0
-  gcp-gcr: circleci/gcp-gcr@0.15
+  gcp-cli: circleci/gcp-cli@3.2.2
+  gcp-gcr: circleci/gcp-gcr@0.16.7

--- a/src/examples/publish-and-rollout-artifact-image.yml
+++ b/src/examples/publish-and-rollout-artifact-image.yml
@@ -1,0 +1,21 @@
+description: >
+  "The simplest example of using this Orb. Logs into GCP, builds and
+  publishes a Docker image, and then rolls the image out to a GKE cluster."
+usage:
+  version: 2.1
+  orbs:
+    gke: circleci/gcp-gke@3.0
+  workflows:
+    main:
+      jobs:
+        # Expects environment variables with the default names
+        # used by the circleci/gcp-cli orb's initialize command
+        # https://circleci.com/orbs/registry/orb/circleci/gcp-cli#commands-initialize
+        - gke/publish-and-rollout-image:
+            cluster: gcp-testing
+            deployment: demo
+            container: app
+            image: myimage
+            tag: "$CIRCLE_SHA1"
+            registry_url: us-docker.pkg.dev
+            repository: docker-repositories

--- a/src/examples/publish-and-rollout-artifact-image.yml
+++ b/src/examples/publish-and-rollout-artifact-image.yml
@@ -1,6 +1,6 @@
 description: >
-  "The simplest example of using this Orb. Logs into GCP, builds and
-  publishes a Docker image, and then rolls the image out to a GKE cluster."
+  "The example of using this Orb when using Artifact Registry instead of Container Registry. Logs into GCP, builds and
+  publishes a Docker image into Artifact Registry, and then rolls the image out to a GKE cluster."
 usage:
   version: 2.1
   orbs:

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -9,7 +9,7 @@ parameters:
 
   tag:
     type: string
-    default: "2.7"
+    default: "3.8"
     description: Image tag
 
 docker:

--- a/src/jobs/publish-and-rollout-image.yml
+++ b/src/jobs/publish-and-rollout-image.yml
@@ -13,9 +13,16 @@ parameters:
     description: "The Kubernetes container name."
     type: string
   registry_url:
-    description: The GCR registry URL from ['', us, eu, asia].gcr.io
+    description: The GCR registry URL from ['', us, eu, asia].gcr.io,
+      or an artifact registry url from [GOOGLE_COMPUTE_REGION, us, eu, asia]-docker.pkg.dev
     type: string
     default: gcr.io
+  repository:
+    type: string
+    default: ""
+    description: >
+      The Artifact Registry requires a HOST-NAME/PROJECT-ID/REPOSITORY/IMAGE format.
+      If pushing to the Artifact Registry, the repository to push the image to
   image:
     description: A name for your docker image
     type: string
@@ -183,6 +190,7 @@ steps:
         set +x
   - gcp-gcr/build-image:
       registry-url: <<parameters.registry_url>>
+      repository: <<parameters.repository>>
       google-project-id: <<parameters.google_project_id>>
       image: <<parameters.image>>
       tag: << parameters.tag >>
@@ -192,17 +200,37 @@ steps:
       extra_build_args: <<parameters.extra_build_args>>
   - gcp-gcr/push-image:
       registry-url: <<parameters.registry_url>>
+      repository: <<parameters.repository>>
       google-project-id: <<parameters.google_project_id>>
       image: <<parameters.image>>
       tag: <<parameters.tag>>
   - update-kubeconfig-with-credentials:
       cluster: "<<parameters.cluster>>"
       use_gke_cloud_auth_plugin: true
-  - rollout-image:
-      deployment: "<<parameters.deployment>>"
-      container: "<<parameters.container>>"
-      image: "<<parameters.registry_url>>/$<<parameters.google_project_id>>/<<parameters.image>>"
-      tag: "<<parameters.tag>>"
-      namespace: "<<parameters.namespace>>"
-      dry_run: "<<parameters.dry_run>>"
-      workload_type: "<<parameters.workload_type>>"
+  - when:
+      condition:
+        equal: [ "", << parameters.repository >> ]
+      steps:
+        - rollout-image:
+            deployment: "<<parameters.deployment>>"
+            container: "<<parameters.container>>"
+            image: "<<parameters.registry_url>>/$<<parameters.google_project_id>>/<<parameters.image>>"
+            tag: "<<parameters.tag>>"
+            namespace: "<<parameters.namespace>>"
+            dry_run: "<<parameters.dry_run>>"
+            workload_type: "<<parameters.workload_type>>"
+  - when:
+      condition:
+        not:
+          equal: [ "", << parameters.repository >> ]
+      steps:
+        - rollout-image:
+            deployment: "<<parameters.deployment>>"
+            container: "<<parameters.container>>"
+            image: "<<parameters.registry_url>>/$<<parameters.google_project_id>>/<<parameters.repository>>/<<parameters.image>>"
+            tag: "<<parameters.tag>>"
+            namespace: "<<parameters.namespace>>"
+            dry_run: "<<parameters.dry_run>>"
+            workload_type: "<<parameters.workload_type>>"
+
+  

--- a/src/jobs/publish-and-rollout-image.yml
+++ b/src/jobs/publish-and-rollout-image.yml
@@ -232,5 +232,3 @@ steps:
             namespace: "<<parameters.namespace>>"
             dry_run: "<<parameters.dry_run>>"
             workload_type: "<<parameters.workload_type>>"
-
-  


### PR DESCRIPTION
Bump gcp-cli and gcp-gcr Orbs to support the extra new parameter `repository` when wanting to push the image to GCP Artifact Registry instead of Container Registry